### PR TITLE
fix-108 Ensure JSON tag structure complies with Cucumber schema

### DIFF
--- a/Sources/CucumberSwift/Gherkin/Parser/Scenario.swift
+++ b/Sources/CucumberSwift/Gherkin/Parser/Scenario.swift
@@ -9,7 +9,7 @@
 import Foundation
 public class Scenario: NSObject, Taggable, Positionable {
     public private(set)  var title = ""
-    public private(set)  var tags = [String]()
+    public internal(set)  var tags = [String]()
     public internal(set) var steps = [Step]()
     public internal(set) var feature: Feature?
     public private(set)  var location: Lexer.Position

--- a/Sources/CucumberSwift/Reporter/JSONReporter.swift
+++ b/Sources/CucumberSwift/Reporter/JSONReporter.swift
@@ -79,6 +79,10 @@ public class CucumberJSONReporter: CucumberTestObserver {
 }
 
 extension CucumberJSONReporter {
+    struct Tag: Encodable {
+        let line: UInt
+        let name: String
+    }
     class Feature: Encodable {
         let uri: String
         let id: String
@@ -87,7 +91,7 @@ extension CucumberJSONReporter {
         let keyword: String = "Feature"
         var elements: [Scenario] = []
         let line: UInt
-        var tags: [String] = []
+        var tags: [Tag] = []
 
         init(_ feature: CucumberSwift.Feature) {
             uri = feature.uri
@@ -96,7 +100,7 @@ extension CucumberJSONReporter {
             name = feature.title
             description = feature.desc
             line = feature.location.line
-            tags = feature.tags
+            tags = feature.tags.map { Tag(line: 1, name: $0) }
         }
     }
 
@@ -108,7 +112,7 @@ extension CucumberJSONReporter {
         let description: String
         var steps: [Step] = []
         var line: UInt
-        var tags: [String] = []
+        var tags: [Tag] = []
 
         init(_ scenario: CucumberSwift.Scenario) {
 //            #warning("Add better id logic so all whitespace is replaced")
@@ -117,7 +121,7 @@ extension CucumberJSONReporter {
 //            #warning("Fix this")
             description = ""
             line = scenario.location.line
-            tags = scenario.tags
+            tags = scenario.tags.map { Tag(line: 1, name: $0) }
         }
     }
 

--- a/Sources/CucumberSwift/Runner/Cucumber.swift
+++ b/Sources/CucumberSwift/Runner/Cucumber.swift
@@ -11,7 +11,7 @@ import XCTest
 import CucumberSwiftExpressions
 
 @objc public class Cucumber: NSObject { // swiftlint:disable:this type_body_length
-    static var shared = Cucumber()
+    @objc public static var shared = Cucumber()
 
     var features = [Feature]()
     var currentStep: Step?

--- a/Tests/CucumberSwiftTests/Reporter/ReporterTests.swift
+++ b/Tests/CucumberSwiftTests/Reporter/ReporterTests.swift
@@ -143,11 +143,15 @@ class ReporterTests: XCTestCase {
         if let schema = json as? [String: Any] {
             // access dictionary values
             let reporter = try XCTUnwrap(Cucumber.shared.reporters.compactMap { $0 as? CucumberJSONReporter }.first)
-            Feature("F1") {
+            let feature = Feature("F1") {
                 Description("A test feature")
                 Scenario("S1") {
                     Given(I: print(""))
                 }
+            }
+            feature.tags = ["@tag1", "@tag2"]
+            if !feature.scenarios.isEmpty {
+                feature.scenarios[0].tags = ["@tag3", "@tag4"]
             }
             reporter.testSuiteStarted(at: Date())
             Cucumber.shared.executeFeatures()


### PR DESCRIPTION
## Description

This PR updates the `JSONReporter` to ensure the tag structure complies with the official Cucumber JSON schema. 

Previously, tags were represented as strings (`["@tag1", "@tag2"]`), but the schema expects objects with `line` and `name` fields.

This pull request resolves [Issue #108](https://github.com/cucumberswift/CucumberSwift/issues/108)
