### PR TITLE
Parse and propagate Scenario/Scenario Outline description

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -15,7 +15,16 @@
         "repositoryURL": "https://github.com/apple/swift-docc-plugin",
         "state": {
           "branch": null,
-          "revision": "3303b164430d9a7055ba484c8ead67a52f7b74f6",
+          "revision": "3e4f133a77e644a5812911a0513aeb7288b07d06",
+          "version": "1.4.5"
+        }
+      },
+      {
+        "package": "SymbolKit",
+        "repositoryURL": "https://github.com/swiftlang/swift-docc-symbolkit",
+        "state": {
+          "branch": null,
+          "revision": "b45d1f2ed151d057b54504d653e0da5552844e34",
           "version": "1.0.0"
         }
       }

--- a/Sources/CucumberSwift/DSL/DSLScenarioOutline.swift
+++ b/Sources/CucumberSwift/DSL/DSLScenarioOutline.swift
@@ -13,6 +13,7 @@ public struct ScenarioOutline: ScenarioDSL {
 
     @discardableResult public init<T>(_ title: String,
                                       tags: [String] = [],
+                                      description: String = "",
                                       headers: T.Type,
                                       line: UInt = #line,
                                       column: UInt = #column,
@@ -21,6 +22,7 @@ public struct ScenarioOutline: ScenarioDSL {
         scenarios = examples().map {
             Scenario(with: steps($0),
                      title: title,
+                     description: description,
                      tags: tags,
                      position: Lexer.Position(line: line, column: column))
         }
@@ -28,6 +30,7 @@ public struct ScenarioOutline: ScenarioDSL {
 
     @discardableResult public init<T>(_ title: String,
                                       tags: [String] = [],
+                                      description: String = "",
                                       headers: T.Type,
                                       line: UInt = #line,
                                       column: UInt = #column,
@@ -36,6 +39,7 @@ public struct ScenarioOutline: ScenarioDSL {
         scenarios = examples().map {
             Scenario(with: [steps($0)],
                      title: title,
+                     description: description,
                      tags: tags,
                      position: Lexer.Position(line: line, column: column))
         }
@@ -43,6 +47,7 @@ public struct ScenarioOutline: ScenarioDSL {
 
     @discardableResult public init<T>(_ title: (T) -> String,
                                       tags: [String] = [],
+                                      description: String = "",
                                       headers: T.Type,
                                       line: UInt = #line,
                                       column: UInt = #column,
@@ -51,6 +56,7 @@ public struct ScenarioOutline: ScenarioDSL {
         scenarios = examples().map {
             Scenario(with: steps($0),
                      title: title($0),
+                     description: description,
                      tags: tags,
                      position: Lexer.Position(line: line, column: column))
         }
@@ -58,6 +64,7 @@ public struct ScenarioOutline: ScenarioDSL {
 
     @discardableResult public init<T>(_ title: (T) -> String,
                                       tags: [String] = [],
+                                      description: String = "",
                                       headers: T.Type,
                                       line: UInt = #line,
                                       column: UInt = #column,
@@ -66,6 +73,7 @@ public struct ScenarioOutline: ScenarioDSL {
         scenarios = examples().map {
             Scenario(with: [steps($0)],
                      title: title($0),
+                     description: description,
                      tags: tags,
                      position: Lexer.Position(line: line, column: column))
         }

--- a/Sources/CucumberSwift/DSL/ScenarioDSL.swift
+++ b/Sources/CucumberSwift/DSL/ScenarioDSL.swift
@@ -28,17 +28,28 @@ public protocol ScenarioDSL {
 
 extension Scenario {
     public convenience init(_ title: String,
+                            description: String = "",
                             tags: [String] = [],
                             line: UInt = #line,
                             column: UInt = #column,
                             @StepBuilder _ content: () -> [StepDSL]) {
-        self.init(with: content(), title: title, tags: tags, position: Lexer.Position(line: line, column: column))
+        self.init(with: content(),
+                  title: title,
+                  description: description,
+                  tags: tags,
+                  position: Lexer.Position(line: line, column: column))
     }
     public convenience init(_ title: String,
+                            description: String = "",
                             tags: [String] = [],
                             line: UInt = #line,
                             column: UInt = #column,
                             @StepBuilder _ content: () -> StepDSL) {
-        self.init(with: [content()], title: title, tags: tags, position: Lexer.Position(line: line, column: column))
+        self.init(with: [content()],
+                  title: title,
+                  description: description,
+                  tags: tags,
+                  position: Lexer.Position(line: line, column: column))
     }
 }
+// swiftlint:enable file_types_order

--- a/Sources/CucumberSwift/Gherkin/Parser/Scenario.swift
+++ b/Sources/CucumberSwift/Gherkin/Parser/Scenario.swift
@@ -10,7 +10,8 @@ import Foundation
 public class Scenario: NSObject, Taggable, Positionable {
     public private(set)  var title = ""
     public internal(set)  var tags = [String]()
-    public internal(set) var steps = [Step]()
+    public internal(set)  var steps = [Step]()
+    public internal(set) var desc: String = ""
     public internal(set) var feature: Feature?
     public private(set)  var location: Lexer.Position
     public private(set)  var endLocation: Lexer.Position
@@ -19,11 +20,14 @@ public class Scenario: NSObject, Taggable, Positionable {
     init(with node: AST.ScenarioNode, tags: [String], stepNodes: [AST.StepNode]) {
         location = node.tokens.first?.position ?? .start
         endLocation = .start
+        desc = ""
         super.init()
         self.tags = tags
         for token in node.tokens {
             if case Lexer.Token.title(_, let t) = token {
                 title = t
+            } else if case Lexer.Token.description(_, let t) = token {
+                desc += t + "\n"
             } else if case Lexer.Token.tag(_, let tag) = token {
                 self.tags.append(tag)
             }
@@ -34,12 +38,13 @@ public class Scenario: NSObject, Taggable, Positionable {
         endLocation ?= steps.last?.location
     }
 
-    init(with steps: [Step], title: String?, tags: [String], position: Lexer.Position) {
+    init(with steps: [Step], title: String?, description: String? = "", tags: [String], position: Lexer.Position) {
         location = position
         endLocation = position
         super.init()
         self.steps = steps
         self.title = title ?? ""
+        self.desc = description ?? ""
         self.tags = tags
         setupSteps()
     }
@@ -68,7 +73,7 @@ public class Scenario: NSObject, Taggable, Positionable {
             "keyword": "Scenario",
             "type": "scenario",
             "name": title,
-            "description": "",
+            "description": desc,
             "steps": []
         ]
     }


### PR DESCRIPTION
This pull request adds support for parsing and propagating scenario descriptions from Gherkin feature files into the `Scenario` and `ScenarioOutline` objects. It ensures that any description lines written under a scenario or scenario outline are correctly parsed and attached to each expanded scenario instance, and updates the relevant initializers and serialization logic. Comprehensive tests are included to verify the correct parsing and propagation of descriptions.

**Scenario Description Parsing and Propagation**

* Added a `desc` property to the `Scenario` class, updated its initializers to accept a description, and ensured that the description is included in the serialized output. [[1]](diffhunk://#diff-692497c85f3c93fa5f0d00201219d8b852002d9bc94807a5e4abf09fde4a2e03R14) [[2]](diffhunk://#diff-692497c85f3c93fa5f0d00201219d8b852002d9bc94807a5e4abf09fde4a2e03L37-R47) [[3]](diffhunk://#diff-692497c85f3c93fa5f0d00201219d8b852002d9bc94807a5e4abf09fde4a2e03L71-R76)
* Modified the `ScenarioOutline` DSL struct and its initializers to accept and propagate a description parameter when generating scenarios from examples. [[1]](diffhunk://#diff-5f813378863b2909dc8de8611ce946c1a3588be3926ad3eee673bc245470e927R16) [[2]](diffhunk://#diff-5f813378863b2909dc8de8611ce946c1a3588be3926ad3eee673bc245470e927R25-R33) [[3]](diffhunk://#diff-5f813378863b2909dc8de8611ce946c1a3588be3926ad3eee673bc245470e927R42-R50) [[4]](diffhunk://#diff-5f813378863b2909dc8de8611ce946c1a3588be3926ad3eee673bc245470e927R59-R67) [[5]](diffhunk://#diff-5f813378863b2909dc8de8611ce946c1a3588be3926ad3eee673bc245470e927R76)
* Updated the `ScenarioDSL` protocol extension to allow passing a description to scenario initializers.

**Gherkin Parser Enhancements**

* Implemented logic in `ScenarioOutlineParser` to extract description lines from scenario outlines and propagate them to each expanded scenario. [[1]](diffhunk://#diff-497e88f5fb23847f2612604378ff4df9e20125d9eb6200efe195302786fb504eR19-R78) [[2]](diffhunk://#diff-497e88f5fb23847f2612604378ff4df9e20125d9eb6200efe195302786fb504eR95) [[3]](diffhunk://#diff-497e88f5fb23847f2612604378ff4df9e20125d9eb6200efe195302786fb504eL78-R124)

**Testing**

* Added tests to verify that scenario and scenario outline descriptions are parsed and propagated correctly, and that step parsing remains unaffected.

These changes ensure that scenario descriptions written in Gherkin files are available to consumers of the parsed model, improving documentation and reporting fidelity.…ions

- Add `desc` to `Scenario` and include it in exported JSON (`description` field)
- Parse `.description` tokens in `Scenario` and Scenario Outline bodies
- Propagate Scenario Outline description to each expanded Scenario
- Extend DSL initializers to accept `description:` (default empty) and wire through
- Update `ScenarioOutlineParser` to extract outline description (trims leading/trailing empty lines, preserves inner ones)
- Add tests for scenario and outline descriptions, including value substitution
- Fix SwiftLint: trailing_closure, and local disables for long line/type_body_length where necessary
- Bump `swift-docc-plugin` to 1.4.5 and add `SymbolKit` to Package.resolved

Refs: parsing, DSL, tests